### PR TITLE
🔨 Track Debian apt pins with the Renovate deb datasource

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,16 +38,21 @@
       "managerFilePatterns": ["//Dockerfile$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "\\s\\s(?<depName>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
+        "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_13/{{depName}}"
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
     }
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main,contrib,non-free&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
       "automerge": true
     },
     {


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Applies the same change as hassio-addons/app-vaultwarden#447 to this app.

Repology has become unreliable as a datasource lately: throttling, timeouts, and missing packages. It also forces us to map binary package names onto source package names.

Renovate ships a native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/) that reads the Debian package indices directly, so this switches the apt pins over to it. It indexes **binary** package names, which means `depNameTemplate` becomes plain `{{{package}}}` and the whole name mapping problem disappears.

The registry URLs mirror the apt sources this app actually pulls from, which is the three from `ghcr.io/hassio-addons/debian-base:9.4.0` plus the `contrib non-free` line the Dockerfile appends to `sources.list`:

| Source | Suite | Components |
| --- | --- | --- |
| `deb.debian.org/debian` | `trixie` | `main`, `contrib`, `non-free` |
| `deb.debian.org/debian` | `trixie-updates` | `main` |
| `deb.debian.org/debian-security` | `trixie-security` | `main` |

The extra components matter here: `unrar` is a `non-free` package, so a `main` only registry URL would never resolve it. Verified against the live indices for `trixie`:

- `uuid-runtime` `2.41-5` resolves from `main`
- `unrar` `1:7.1.8-1` resolves from `non-free`
- `contrib` currently carries none of our pins, but is included because the Dockerfile enables it

`xmlstarlet` is deliberately unaffected: it is pinned with `>=` rather than `=`, so the custom manager regex does not match it.

The `deb` datasource uses a `merge` registry strategy, so releases from all three registry URLs are aggregated rather than first one wins.

### Known limitation

The datasource currently hardcodes `Packages.gz`, but `trixie-updates` and `trixie-security` serve only `Packages.xz`. (Their `InRelease` files also list an uncompressed `Packages`, but the archive does not actually serve that file: it 404s, on every suite, including plain `trixie`. The checksum is listed so that apt can verify the index after decompressing it.) Those two suites are therefore inert for now. This fails gracefully: lookups are caught and skipped per component, so `trixie` keeps working, and the other two start working by themselves once renovatebot/renovate#44330 is resolved. They are kept in the config so it stays a truthful description of what the image actually pulls from.

Unlike app-vaultwarden, this app has no pins that currently resolve only from `trixie-updates` or `trixie-security`, so there is no practical impact here today.

Validated with `renovate-config-validator --strict` from Renovate 44.34.1.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Ports hassio-addons/app-vaultwarden#447.

Upstream: renovatebot/renovate#44330

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated Debian package tracking to use Debian’s native package sources.
  * Limited dependency lookups to Debian Trixie, updates, and security repositories for amd64.
  * Improved package name extraction and matching for Debian dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->